### PR TITLE
ci: Remove dependabot ignores for github.com/docker/{docker,cli}

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: github.com/docker/cli
-        update-types:
-          - version-update:semver-major
-      - dependency-name: github.com/docker/docker
-        update-types:
-          - version-update:semver-major
     groups:
       k8s:
         patterns:


### PR DESCRIPTION
Latest versions should now be supported.
