### PR TITLE
fix: Set empty origin auth if no credentials configured 

### DIFF
--- a/pkg/credentialprovider/dynamic/dynamic.go
+++ b/pkg/credentialprovider/dynamic/dynamic.go
@@ -142,12 +142,9 @@ func (p *dynamicProvider) GetCredentials(
 		if err != nil {
 			return nil, fmt.Errorf("failed to get origin credentials: %w", err)
 		}
-	}
-
-	if originAuthFound {
 		authMap[img] = originAuthConfig
 
-		if !mirrorAuthFound || cacheDuration > originCacheDuration {
+		if originAuthFound && (!mirrorAuthFound || cacheDuration > originCacheDuration) {
 			cacheDuration = originCacheDuration
 		}
 	}

--- a/pkg/credentialprovider/dynamic/dynamic_test.go
+++ b/pkg/credentialprovider/dynamic/dynamic_test.go
@@ -122,7 +122,8 @@ func Test_dynamicProvider_GetCredentials(t *testing.T) {
 					CacheKeyType:  credentialproviderv1.ImagePluginCacheKeyType,
 					CacheDuration: &metav1.Duration{Duration: expectedDummyDuration},
 					Auth: map[string]credentialproviderv1.AuthConfig{
-						wildcardDomain: {Username: mirrorUser, Password: mirrorPassword},
+						wildcardDomain:            {Username: mirrorUser, Password: mirrorPassword},
+						"noorigin/image:v1.2.3.4": {Username: "", Password: ""},
 					},
 				},
 			},

--- a/test/e2e/cluster/kind.go
+++ b/test/e2e/cluster/kind.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/namesgenerator"
+	"github.com/onsi/ginkgo/v2"
 	yaml "gopkg.in/yaml.v3"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,6 +78,8 @@ func NewKinDCluster(
 		"--config", cfgFile,
 		"--retain",
 	)
+	cmd.Stdout = ginkgo.GinkgoWriter
+	cmd.Stderr = ginkgo.GinkgoWriter
 
 	err = cmd.Run()
 	if err != nil {

--- a/test/e2e/docker/client.go
+++ b/test/e2e/docker/client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/client"
 )
@@ -82,7 +83,7 @@ func RunContainerInBackground(
 		}
 	}
 
-	out, err := dClient.ImagePull(ctx, containerCfg.Image, types.ImagePullOptions{})
+	out, err := dClient.ImagePull(ctx, containerCfg.Image, image.PullOptions{})
 	defer func() { _ = out.Close() }()
 	if err != nil {
 		_, _ = io.Copy(os.Stderr, out)
@@ -161,7 +162,7 @@ func RetagAndPushImage( //nolint:revive // Lots of args is fine in these tests.
 		out, err := dClient.ImagePull(
 			ctx,
 			srcImage,
-			types.ImagePullOptions{RegistryAuth: authString(pullUsername, pullPassword)},
+			image.PullOptions{RegistryAuth: authString(pullUsername, pullPassword)},
 		)
 		defer func() {
 			if out != nil {
@@ -184,12 +185,12 @@ func RetagAndPushImage( //nolint:revive // Lots of args is fine in these tests.
 	if err := dClient.ImageTag(ctx, srcImage, destImage); err != nil {
 		return fmt.Errorf("failed to retag image: %w", err)
 	}
-	defer func() { _, _ = dClient.ImageRemove(ctx, destImage, types.ImageRemoveOptions{}) }()
+	defer func() { _, _ = dClient.ImageRemove(ctx, destImage, image.RemoveOptions{}) }()
 
 	out, err := dClient.ImagePush(
 		ctx,
 		destImage,
-		types.ImagePushOptions{RegistryAuth: authString(pushUsername, pushPassword)},
+		image.PushOptions{RegistryAuth: authString(pushUsername, pushPassword)},
 	)
 	defer func() {
 		if out != nil {

--- a/test/e2e/suites/mirror/dynamic_credentials_test.go
+++ b/test/e2e/suites/mirror/dynamic_credentials_test.go
@@ -301,7 +301,7 @@ var _ = Describe("Successful",
 					if len(pod.Status.ContainerStatuses) == 0 {
 						return ""
 					}
-					return pod.Status.ContainerStatuses[0].State.Waiting.Reason
+					return ptr.Deref(pod.Status.ContainerStatuses[0].State.Waiting, corev1.ContainerStateWaiting{}).Reason
 				}, time.Minute, time.Second).WithContext(ctx).
 					Should(Or(Equal("ErrImagePull"), Equal("ImagePullBackOff")))
 			})

--- a/test/e2e/suites/mirror/mirror_suite_test.go
+++ b/test/e2e/suites/mirror/mirror_suite_test.go
@@ -8,7 +8,6 @@ package mirror_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -90,6 +89,11 @@ type imageCredentialProviderConfigData struct {
 	MirrorAddress string
 }
 
+type containerdMirrorHostsConfigData struct {
+	MirrorAddress    string
+	MirrorCACertPath string
+}
+
 func testdataPath(f string) string {
 	return filepath.Join("testdata", f)
 }
@@ -169,17 +173,28 @@ var _ = SynchronizedBeforeSuite(
 			filepath.Join(providerBinDir, "static-credential-provider"),
 		)).To(Succeed())
 
+		By("Setting up containerd mirror hosts configuration")
+		containerdMirrorHostsConfigDir := GinkgoT().TempDir()
+		templatedFile, err = os.Create(
+			filepath.Join(containerdMirrorHostsConfigDir, "hosts.toml"),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configTemplates.ExecuteTemplate(
+			templatedFile,
+			"hosts.yaml.tmpl",
+			containerdMirrorHostsConfigData{
+				MirrorAddress:    mirrorRegistry.Address(),
+				MirrorCACertPath: "/etc/containerd/mirror-registry-ca.pem",
+			},
+		)).To(Succeed())
+
 		By("Starting KinD cluster")
 		kindCluster, kcName, kubeconfig, err := cluster.NewKinDCluster(
 			ctx,
 			&v1alpha4.Cluster{
-				KubeadmConfigPatches: []string{
-					kubeadmInitPatchKubeletCredentialProviderExtraArgs,
-					kubeadmJoinPatchKubeletCredentialProviderExtraArgs,
-				},
 				Nodes: []v1alpha4.Node{{
 					Role:  v1alpha4.ControlPlaneRole,
-					Image: "ghcr.io/mesosphere/kind-node:v1.26.4",
+					Image: "ghcr.io/mesosphere/kind-node:v1.30.0",
 					ExtraMounts: []v1alpha4.Mount{{
 						HostPath:      mirrorRegistry.CACertFile(),
 						ContainerPath: "/etc/containerd/mirror-registry-ca.pem",
@@ -187,21 +202,18 @@ var _ = SynchronizedBeforeSuite(
 					}, {
 						HostPath:      providerBinDir,
 						ContainerPath: "/etc/kubernetes/image-credential-provider/",
+					}, {
+						HostPath:      containerdMirrorHostsConfigDir,
+						ContainerPath: "/etc/containerd/certs.d/_default/",
 					}},
 				}},
+				KubeadmConfigPatches: []string{
+					kubeadmInitPatchKubeletCredentialProviderExtraArgs,
+					kubeadmJoinPatchKubeletCredentialProviderExtraArgs,
+				},
 				ContainerdConfigPatches: []string{
-					fmt.Sprintf(
-						`[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-  endpoint = ["https://%[1]s"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
-  endpoint = ["https://%[1]s"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."*"]
-  endpoint = ["https://%[1]s"]
-[plugins."io.containerd.grpc.v1.cri".registry.configs."%[1]s".tls]
-  ca_file   = "/etc/containerd/mirror-registry-ca.pem"
-`,
-						mirrorRegistry.Address(),
-					),
+					`[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"`,
 				},
 			},
 		)

--- a/test/e2e/suites/mirror/mirror_test.go
+++ b/test/e2e/suites/mirror/mirror_test.go
@@ -47,7 +47,8 @@ var _ = Describe("Successful",
 				Expect(
 					pod.Status.ContainerStatuses[0].State.Waiting.Message,
 				).To(HaveSuffix("not found"))
-			})
+			},
+		)
 
 		It("pull image from origin when it does not exist in mirror",
 			func(ctx SpecContext) {
@@ -61,7 +62,8 @@ var _ = Describe("Successful",
 					return objStatus(pod, scheme.Scheme)
 				}, time.Minute, time.Second).WithContext(ctx).
 					Should(Equal(status.CurrentStatus))
-			})
+			},
+		)
 
 		It("pull image that only exists in mirror using origin style address",
 			func(ctx SpecContext) {
@@ -90,7 +92,8 @@ var _ = Describe("Successful",
 					return objStatus(pod, scheme.Scheme)
 				}, time.Minute, time.Second).WithContext(ctx).
 					Should(Equal(status.CurrentStatus))
-			})
+			},
+		)
 
 		It("pull image that only exists in mirror using mirror address",
 			func(ctx SpecContext) {
@@ -120,5 +123,7 @@ var _ = Describe("Successful",
 					return objStatus(pod, scheme.Scheme)
 				}, time.Minute, time.Second).WithContext(ctx).
 					Should(Equal(status.CurrentStatus))
-			})
-	})
+			},
+		)
+	},
+)

--- a/test/e2e/suites/mirror/testdata/hosts.yaml.tmpl
+++ b/test/e2e/suites/mirror/testdata/hosts.yaml.tmpl
@@ -1,6 +1,3 @@
 [host."{{ .MirrorAddress }}"]
   capabilities = ["pull", "resolve"]
   ca = "{{ .MirrorCACertPath }}"
-  # don't rely on Containerd to add the v2/ suffix
-  # there is a bug where it is added incorrectly for mirrors with a path
-  override_path = true

--- a/test/e2e/suites/mirror/testdata/hosts.yaml.tmpl
+++ b/test/e2e/suites/mirror/testdata/hosts.yaml.tmpl
@@ -1,0 +1,6 @@
+[host."{{ .MirrorAddress }}"]
+  capabilities = ["pull", "resolve"]
+  ca = "{{ .MirrorCACertPath }}"
+  # don't rely on Containerd to add the v2/ suffix
+  # there is a bug where it is added incorrectly for mirrors with a path
+  override_path = true

--- a/test/e2e/suites/mirror/testdata/static-image-credentials.json.tmpl
+++ b/test/e2e/suites/mirror/testdata/static-image-credentials.json.tmpl
@@ -5,7 +5,8 @@
   "cacheDuration":"0s",
   "auth":{
     {{- if .MirrorAddress }}
-    {{ printf "%q" .MirrorAddress }}: {"username": {{ printf "%q" .MirrorUsername }}, "password": {{ printf "%q" .MirrorPassword }}}{{ end }}{{ if .DockerHubUsername }},
+    {{ printf "%q" .MirrorAddress }}: {"username": {{ printf "%q" .MirrorUsername }}, "password": {{ printf "%q" .MirrorPassword }}}{{ if .DockerHubUsername }},{{ end }}{{ end }}
+    {{- if .DockerHubUsername }}
     "docker.io": {"username": {{ printf "%q" .DockerHubUsername }}, "password": {{ printf "%q" .DockerHubPassword }}}
     {{- end }}
   }

--- a/test/e2e/suites/mirror/testdata/static-image-credentials.json.tmpl
+++ b/test/e2e/suites/mirror/testdata/static-image-credentials.json.tmpl
@@ -5,8 +5,8 @@
   "cacheDuration":"0s",
   "auth":{
     {{- if .MirrorAddress }}
-    {{ printf "%q" .MirrorAddress }}: {"username": {{ printf "%q" .MirrorUsername }}, "password": {{ printf "%q" .MirrorPassword }}},
-    {{- end }}
+    {{ printf "%q" .MirrorAddress }}: {"username": {{ printf "%q" .MirrorUsername }}, "password": {{ printf "%q" .MirrorPassword }}}{{ end }}{{ if .DockerHubUsername }},
     "docker.io": {"username": {{ printf "%q" .DockerHubUsername }}, "password": {{ printf "%q" .DockerHubPassword }}}
+    {{- end }}
   }
 }


### PR DESCRIPTION
This fixes an incorrect 401 returned from registry if no credentials are
returned from the kubelet credential provider.